### PR TITLE
Aprimorando performance do bulk import de cooperados

### DIFF
--- a/src/modules/cooperated/cooperated.service.ts
+++ b/src/modules/cooperated/cooperated.service.ts
@@ -87,7 +87,6 @@ export class CooperatedService {
       }
       await queryRunner.commitTransaction();
     } catch (err) {
-      console.log(err)
       await queryRunner.rollbackTransaction();
     } finally {
       await queryRunner.release();


### PR DESCRIPTION
# Por que a mudança é necessária?
Performance anterior do bulk import para 10_000 cooperados era de cerca de 32 segundos.
Com a alteracao diminuiu para 9 segundos, em media.

# Como a alteração foi abordada?
Foi utilizada getTransaction do NestJS primeiramente, mas algumas coisas estavam depreciadas e outras nao garantiam atomicidade. Decidi mudar para utilizar o Datasource do TypeORM e reutilizar a transaction. Nao funciona tao bem quanto, mas temos um ganho de 70% de performance

# Como testar?
milagroso:
 

```
import requests
import random
import string
import time

def generate_random_string(length):
    return ''.join(random.choices(string.ascii_letters, k=length))

def generate_test_data(num_entries):
    return [
        {
            'email': f'email_{i}@example.com',
            'firstName': generate_random_string(10),
            'lastName': generate_random_string(10),
            'phone': f'12345678{i}',
            'document': '37955312090'
        } for i in range(num_entries)
    ]

def login():
    endpoint = 'http://localhost:3000/api/v1/auth/admin/email/login'
    response = requests.post(endpoint, json={'email': 'admin@example.com', 'password': 'password123'})
    if response.status_code == 200:
        return response.json()['token']
    else:
        print(f'Login failed with status code {response.status_code} {response.content}')
        return None

def test_bulk_insert(num_entries):
    bearer_token = login()
    if bearer_token:
        endpoint = 'http://localhost:3000/api/v1/cooperateds/bulk'
        test_data = generate_test_data(num_entries)

        headers = {'Authorization': f'Bearer {bearer_token}'}

        start_time = time.time()

        response = requests.post(endpoint, json=test_data, headers=headers)

        end_time = time.time()

        if response.status_code == 201:
            print(f'Bulk insert of {num_entries} entries took {end_time - start_time:.4f} seconds')
        else:
            print(f'Error: Bulk insert failed with status code {response.status_code} - {response.content}')

if __name__ == '__main__':
    test_bulk_insert(10_000)
```
