### PR TITLE
:sparkles: feat: Ajustando Custom Filter Assertions, limpando algumas logicas e adicionando indexes

### DIFF
--- a/src/infrastructure/custom-transforms.ts
+++ b/src/infrastructure/custom-transforms.ts
@@ -1,0 +1,10 @@
+import { Transform } from "class-transformer";
+
+export function NumericOnlyTransform() {
+  return Transform(({ value }) => {
+    if (typeof value === "string") {
+      return value.replace(/\D/g, "");
+    }
+    return value;
+  });
+}

--- a/src/infrastructure/filters/custom-exception-filter.ts
+++ b/src/infrastructure/filters/custom-exception-filter.ts
@@ -4,7 +4,6 @@ import { BusinessException } from "../exceptions/business.exception";
 import { ResourceNotFoundException } from "../exceptions/resource-not-found.exception";
 import { ProxyException } from "../exceptions/proxy.exception";
 import { InvalidInputException } from "../exceptions/invalid-input.exception";
-import { QueryFailedError } from "typeorm";
 
 @Injectable()
 export class CustomExceptionFilter implements ExceptionFilter {

--- a/src/infrastructure/filters/custom-exception-filter.ts
+++ b/src/infrastructure/filters/custom-exception-filter.ts
@@ -4,6 +4,7 @@ import { BusinessException } from "../exceptions/business.exception";
 import { ResourceNotFoundException } from "../exceptions/resource-not-found.exception";
 import { ProxyException } from "../exceptions/proxy.exception";
 import { InvalidInputException } from "../exceptions/invalid-input.exception";
+import { QueryFailedError } from "typeorm";
 
 @Injectable()
 export class CustomExceptionFilter implements ExceptionFilter {

--- a/src/main.ts
+++ b/src/main.ts
@@ -36,6 +36,7 @@ export async function bootstrap(): Promise<AppBootStrap> {
 
   app.use(json({ limit: "50mb" }));
   app.use(urlencoded({ extended: true, limit: "50mb" }));
+  app.useGlobalFilters(new CustomExceptionFilter());
 
   /**
    * use in case of implementing trace via aws xray

--- a/src/modules/cooperated/cooperated.service.ts
+++ b/src/modules/cooperated/cooperated.service.ts
@@ -18,18 +18,10 @@ export class CooperatedService {
   ) {}
 
   async create(createCooperatedDto: CreateCooperatedDto) {
-    const normalizedDocument = createCooperatedDto.document.replace(/\D/g, "");
-    const alreadyOneWithDocument = await this.cooperatedRepository.findOne({
-      where: {
-        document: normalizedDocument,
-      },
-    });
-    if (alreadyOneWithDocument) throw new UnprocessableEntityException("document already exists");
-
     const organization = await this.organizationService.findOne({ id: +createCooperatedDto.organization });
     if (!organization) throw new UnprocessableEntityException("organization of provided organization is not found");
 
-    return this.cooperatedRepository.save(this.cooperatedRepository.create({ ...createCooperatedDto, document: normalizedDocument, organization }));
+    return this.cooperatedRepository.save(this.cooperatedRepository.create({ ...createCooperatedDto, organization }));
   }
 
   findManyWithPagination(paginationOptions: IPaginationOptions): Promise<Cooperated[]> {

--- a/src/modules/cooperated/dto/create-cooperated.dto.ts
+++ b/src/modules/cooperated/dto/create-cooperated.dto.ts
@@ -1,17 +1,18 @@
 import { Transform } from "class-transformer";
 import { ApiProperty } from "@nestjs/swagger";
-import { IsEmail, IsInt, IsNotEmpty, IsPhoneNumber, Max, Min, Validate, isNumber } from "class-validator";
+import { IsEmail, IsNotEmpty, IsPhoneNumber, Validate } from "class-validator";
 import { IsNotExist } from "../../../utils/validators/is-not-exists.validator";
 import { lowerCaseTransformer } from "../../../utils/transformers/lower-case.transformer";
 import { IsValidCpfOrCnpj } from "../../../utils/validators/is-document.validator";
 import { OrganizationEntity } from "src/modules/organization/entities/organization.entity";
+import { NumericOnlyTransform } from "src/infrastructure/custom-transforms";
 
 export class CreateCooperatedDto {
   @ApiProperty({ example: "test1@example.com" })
   @Transform(lowerCaseTransformer)
   @IsNotEmpty()
   @Validate(IsNotExist, ["Cooperated"], {
-    message: "emailAlreadyExists",
+    message: "Email already exists",
   })
   @IsEmail()
   email: string;
@@ -27,11 +28,16 @@ export class CreateCooperatedDto {
   @ApiProperty({ example: "+5511995039284" })
   @IsNotEmpty()
   @IsPhoneNumber("BR")
+  @NumericOnlyTransform()
   phone: string;
 
   @ApiProperty({ example: "44444444444" })
   @IsNotEmpty()
   @IsValidCpfOrCnpj()
+  @NumericOnlyTransform()
+  @Validate(IsNotExist, ["Cooperated"], {
+    message: "Document already exists",
+  })
   document: string;
 
   @ApiProperty({ example: 2 })

--- a/src/modules/cooperated/entities/cooperated.entity.ts
+++ b/src/modules/cooperated/entities/cooperated.entity.ts
@@ -1,4 +1,4 @@
-import { Column, CreateDateColumn, DeleteDateColumn, Entity, ManyToOne, PrimaryGeneratedColumn, UpdateDateColumn } from "typeorm";
+import { Column, CreateDateColumn, DeleteDateColumn, Entity, Index, ManyToOne, PrimaryGeneratedColumn, UpdateDateColumn } from "typeorm";
 import { EntityHelper } from "../../../utils/entity-helper";
 import { Expose } from "class-transformer";
 import { OrganizationEntity } from "src/modules/organization/entities/organization.entity";
@@ -8,7 +8,8 @@ export class Cooperated extends EntityHelper {
   @PrimaryGeneratedColumn()
   id: number;
 
-  @Column({ type: String, unique: true, nullable: true })
+  @Index({ unique: true })
+  @Column({ type: String, nullable: true })
   @Expose({ groups: ["me", "admin"] })
   email: string | null;
 
@@ -21,6 +22,7 @@ export class Cooperated extends EntityHelper {
   @Column({ type: String, nullable: true })
   phone: string | null;
 
+  @Index({ unique: true })
   @Column({ type: String, nullable: true })
   document: string | null;
 

--- a/test/user/cooperated.e2e-spec.ts
+++ b/test/user/cooperated.e2e-spec.ts
@@ -3,33 +3,7 @@ import { HttpStatus } from "@nestjs/common";
 import { Cooperated } from "../../src/modules/cooperated/entities/cooperated.entity";
 import { OrganizationEntity } from "../../src/modules/organization/entities/organization.entity";
 import { ADMIN_EMAIL, ADMIN_PASSWORD, APP_URL, TESTER_EMAIL, TESTER_PASSWORD } from "../utils/constants";
-
-function generateCPF(): string {
-  const getRandomDigit = () => Math.floor(Math.random() * 10);
-
-  const calculateDigit = (cpfArray: number[], factor: number): number => {
-    const total = cpfArray.reduce((sum, num, index) => sum + num * (factor - index), 0);
-    const remainder = total % 11;
-    return remainder < 2 ? 0 : 11 - remainder;
-  };
-
-  // generate the first 9 digits of CPF
-  const cpfArray = Array.from({ length: 9 }, getRandomDigit);
-
-  // Calcule the first digit of verificator
-  const firstDigit = calculateDigit(cpfArray, 10);
-  cpfArray.push(firstDigit);
-
-  // Calcule the second digit of verificator
-  const secondDigit = calculateDigit(cpfArray, 11);
-  cpfArray.push(secondDigit);
-
-  // Convert the array of numbers to an string of CPF format
-  const cpf = cpfArray.join("");
-
-  // Using CPF Mask
-  return cpf.replace(/(\d{3})(\d{3})(\d{3})(\d{2})/, "$1.$2.$3-$4");
-}
+import { generateCPFNumbers } from "../utils/generators";
 
 function FactoryCooperated(): Partial<Cooperated> {
   return {
@@ -37,7 +11,7 @@ function FactoryCooperated(): Partial<Cooperated> {
     firstName: "Morgan",
     lastName: "Stark",
     phone: "+551677777777",
-    document: generateCPF(),
+    document: generateCPFNumbers(),
   };
 }
 
@@ -45,7 +19,7 @@ function FactoryOrganization(): Partial<OrganizationEntity> {
   return {
     name: "Morgan",
     email: `fakeemail2${Date.now()}@gmail.com`,
-    document: generateCPF(),
+    document: generateCPFNumbers(),
   };
 }
 
@@ -94,7 +68,7 @@ describe("CooperatedController (e2e)", () => {
     // creating an cooperate
     await request(app)
       .post(`/${process.env.API_PREFIX}/v1/cooperateds`)
-      .send({ ...FactoryCooperated(), organization: organizationId, document: generateCPF() })
+      .send({ ...FactoryCooperated(), organization: organizationId, document: generateCPFNumbers() })
       .auth(tokenAdmin, {
         type: "bearer",
       })
@@ -105,7 +79,7 @@ describe("CooperatedController (e2e)", () => {
 
   describe("creating", () => {
     it("New cooperated entity", async () => {
-      const mockCooperated = { ...FactoryCooperated(), organization: organizationId, document: generateCPF() };
+      const mockCooperated = { ...FactoryCooperated(), organization: organizationId, document: generateCPFNumbers() };
 
       await request(app)
         .post(`/${process.env.API_PREFIX}/v1/cooperateds`)
@@ -117,7 +91,7 @@ describe("CooperatedController (e2e)", () => {
     });
     describe("(error)", () => {
       it("New cooperated entity with document already inserted", async () => {
-        const firstDocument = generateCPF();
+        const firstDocument = generateCPFNumbers();
         await request(app)
           .post(`/${process.env.API_PREFIX}/v1/cooperateds`)
           .send({ ...FactoryCooperated(), organization: organizationId, document: firstDocument })
@@ -135,13 +109,14 @@ describe("CooperatedController (e2e)", () => {
           })
           .send(mockCooperated)
           .expect(HttpStatus.UNPROCESSABLE_ENTITY);
-        expect(secondOne.body.message).toBe("document already exists");
+
+        expect(secondOne.body.errors.document).toBe("Document already exists");
       });
 
       it("New cooperated entity with organization not found", async () => {
         const response = await request(app)
           .post(`/${process.env.API_PREFIX}/v1/cooperateds`)
-          .send({ ...FactoryCooperated(), organization: 3232, document: generateCPF() })
+          .send({ ...FactoryCooperated(), organization: 3232, document: generateCPFNumbers() })
           .auth(tokenAdmin, {
             type: "bearer",
           })

--- a/test/utils/generators.ts
+++ b/test/utils/generators.ts
@@ -1,25 +1,3 @@
-export function generateCPF(): string {
-  const getRandomDigit = () => Math.floor(Math.random() * 10);
-
-  const calculateDigit = (cpfArray: number[], factor: number): number => {
-    const total = cpfArray.reduce((sum, num, index) => sum + num * (factor - index), 0);
-    const remainder = total % 11;
-    return remainder < 2 ? 0 : 11 - remainder;
-  };
-
-  const cpfArray = Array.from({ length: 9 }, getRandomDigit);
-
-  const firstDigit = calculateDigit(cpfArray, 10);
-  cpfArray.push(firstDigit);
-
-  const secondDigit = calculateDigit(cpfArray, 11);
-  cpfArray.push(secondDigit);
-
-  const cpf = cpfArray.join("");
-
-  return cpf.replace(/(\d{3})(\d{3})(\d{3})(\d{2})/, "$1.$2.$3-$4");
-}
-
 export function generateCPFNumbers(): string {
   const getRandomDigit = () => Math.floor(Math.random() * 10);
 
@@ -38,4 +16,8 @@ export function generateCPFNumbers(): string {
   cpfArray.push(secondDigit);
 
   return cpfArray.join("");
+}
+
+export function generateCPF(): string {
+  return generateCPFNumbers().replace(/(\d{3})(\d{3})(\d{3})(\d{2})/, "$1.$2.$3-$4");
 }

--- a/test/utils/generators.ts
+++ b/test/utils/generators.ts
@@ -1,0 +1,41 @@
+export function generateCPF(): string {
+  const getRandomDigit = () => Math.floor(Math.random() * 10);
+
+  const calculateDigit = (cpfArray: number[], factor: number): number => {
+    const total = cpfArray.reduce((sum, num, index) => sum + num * (factor - index), 0);
+    const remainder = total % 11;
+    return remainder < 2 ? 0 : 11 - remainder;
+  };
+
+  const cpfArray = Array.from({ length: 9 }, getRandomDigit);
+
+  const firstDigit = calculateDigit(cpfArray, 10);
+  cpfArray.push(firstDigit);
+
+  const secondDigit = calculateDigit(cpfArray, 11);
+  cpfArray.push(secondDigit);
+
+  const cpf = cpfArray.join("");
+
+  return cpf.replace(/(\d{3})(\d{3})(\d{3})(\d{2})/, "$1.$2.$3-$4");
+}
+
+export function generateCPFNumbers(): string {
+  const getRandomDigit = () => Math.floor(Math.random() * 10);
+
+  const calculateDigit = (cpfArray: number[], factor: number): number => {
+    const total = cpfArray.reduce((sum, num, index) => sum + num * (factor - index), 0);
+    const remainder = total % 11;
+    return remainder < 2 ? 0 : 11 - remainder;
+  };
+
+  const cpfArray = Array.from({ length: 9 }, getRandomDigit);
+
+  const firstDigit = calculateDigit(cpfArray, 10);
+  cpfArray.push(firstDigit);
+
+  const secondDigit = calculateDigit(cpfArray, 11);
+  cpfArray.push(secondDigit);
+
+  return cpfArray.join("");
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,7 +23,7 @@
       "node_modules/@types"
     ],
     "types": [
-      "node"
+      "node", "jest"
     ], 
     "moduleResolution": "node",
     "resolveJsonModule": true,


### PR DESCRIPTION
# Por que a mudança é necessária?
Em uma PR anterior nós removemos o Custom Exception Filter por ter barrado alguns testes e2e. Essa PR visa voltar a utilizá-lo.

# Como a alteração foi abordada?
Adicionando validacoes ja padronizadas nos decorators do projeto para validacoes de document/email ja existentes. 
Fora adicionado também unique indexes para previnir que, mesmo quando o class-validator nao barrar algo, o estado do banco de dados permaneca limpo e consistente

# Como testar?
Executando os testes:
```bash
npm run test:e2e
```

E tentando adicionar o mesmo cooperado duas vezes. Considerando o mesmo cooperado como: o mesmo email e/ou mesmo documento.
Teste tambem o cleanup do documento e telefone, pois quando salvamos no banco, devera ser um valor apenas numerico. Caso futuramente o front precise/queira um valor ja formatado, nos podemos formatar na camada responsavel pela distribuicao dos dados e nao diretamente no banco
