### PR TITLE
criando o endpoint /requests/godfather

### DIFF
--- a/src/modules/accidents/accidents.module.ts
+++ b/src/modules/accidents/accidents.module.ts
@@ -10,10 +10,15 @@ import { FileService } from "../file/file.service";
 import { RequestEntity } from "../request/entities/request.entity";
 import { FileEntity } from "../file/entities/file.entity";
 import { User } from "../user/entities/user.entity";
+import { CooperatedService } from "../cooperated/cooperated.service";
+import { CooperatedEntity } from "../cooperated/entities/cooperated.entity";
+import { OrganizationEntity } from "../organization/entities/organization.entity";
+import { OrganizationService } from "../organization/organization.service";
+import { UsersService } from "../user/users.service";
 
 @Module({
-  imports: [TypeOrmModule.forFeature([AccidentEntity, RequestEntity, FileEntity, User])],
+  imports: [TypeOrmModule.forFeature([AccidentEntity, RequestEntity, CooperatedEntity, OrganizationEntity, FileEntity, User])],
   controllers: [AccidentsController],
-  providers: [IsExist, IsNotExist, AccidentsService, RequestService, FileService],
+  providers: [IsExist, IsNotExist, AccidentsService, CooperatedService, OrganizationService, RequestService, FileService, UsersService],
 })
 export class AccidentsModule {}

--- a/src/modules/request/dto/create-request-for-others.dto.ts
+++ b/src/modules/request/dto/create-request-for-others.dto.ts
@@ -1,0 +1,62 @@
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  IsNotEmpty,
+  IsOptional,
+  MinLength,
+  Validate,
+  ValidateIf
+} from 'class-validator';
+import { IsExist } from 'src/utils/validators/is-exists.validator';
+import { RequestStatusEntity } from '../status/entities/request-status.entity';
+import { RequestHelpTypeEntity } from '../help-type/entities/request-help-type.entity';
+import { IsValidCpfOrCnpjConstraint } from 'src/utils/validators/is-document.validator';
+
+export class CreateRequestForOthersDto {
+  @ApiProperty({ example: 'Título' })
+  @IsNotEmpty()
+  title: string;
+
+  @ApiProperty({ example: 'Descrição' })
+  @IsNotEmpty()
+  description: string;
+
+  @ApiProperty({ example: '1000' })
+  @IsNotEmpty()
+  amount: number;
+
+  @ApiProperty({ type: RequestStatusEntity })
+  @IsOptional()
+  status?: RequestStatusEntity;
+
+  @ApiProperty({ type: RequestHelpTypeEntity })
+  @IsNotEmpty()
+  helpType: RequestHelpTypeEntity;
+
+  @ApiProperty({ example: '99999999999' })
+  @MinLength(11)
+  @Validate(IsValidCpfOrCnpjConstraint, {
+    message: 'invalidDocument',
+  })
+  @IsNotEmpty()
+  documentOfAssisted: string;
+
+  @ApiProperty()
+  @ValidateIf(req => (!req.financialBank && !req.financialAgency && !req.financialAccount) || req.financialPixkey)
+  @IsNotEmpty()
+  financialPixkey?: string;
+
+  @ApiProperty()
+  @ValidateIf(req => !req.financialPixkey || req.financialBank)
+  @IsNotEmpty()
+  financialBank?: string;
+
+  @ApiProperty()
+  @ValidateIf(req => !req.financialPixkey || req.financialAgency)
+  @IsNotEmpty()
+  financialAgency?: string;
+
+  @ApiProperty()
+  @ValidateIf(req => !req.financialPixkey || req.financialAccount)
+  @IsNotEmpty()
+  financialAccount?: string;
+}

--- a/src/modules/request/request.controller.ts
+++ b/src/modules/request/request.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Post, Body, Patch, Param, Delete, UseGuards, HttpStatus, HttpCode, DefaultValuePipe, ParseIntPipe, Query, Request } from '@nestjs/common';
+import { Controller, Get, Post, Body, Patch, Param, Delete, UseGuards, HttpStatus, HttpCode, DefaultValuePipe, ParseIntPipe, Query, Request, Response, Res } from '@nestjs/common';
 import { RequestService } from './request.service';
 import { CreateRequestDto } from './dto/create-request.dto';
 import { UpdateRequestDto } from './dto/update-request.dto';
@@ -10,6 +10,7 @@ import { RolesGuard } from '../user/roles/roles.guard';
 import { infinityPagination } from 'src/utils/infinity-pagination';
 import { NullableType } from 'src/utils/types/nullable.type';
 import { RequestEntity } from './entities/request.entity';
+import { CreateRequestForOthersDto } from './dto/create-request-for-others.dto';
 
 @ApiBearerAuth()
 @Roles(UserRoleEnum.user)
@@ -26,6 +27,12 @@ export class RequestController {
   @HttpCode(HttpStatus.CREATED)
   create(@Request() request, @Body() createRequestDto: CreateRequestDto) {
     return this.requestService.create(request.user, createRequestDto);
+  }
+
+  @Post("/godfather")
+  @HttpCode(HttpStatus.CREATED)
+  async createForOthers(@Request() request, @Body() createRequestForOthersDto: CreateRequestForOthersDto) {   
+    return await this.requestService.createForOthers(request.user, createRequestForOthersDto);
   }
 
   @Get()

--- a/src/modules/request/request.module.ts
+++ b/src/modules/request/request.module.ts
@@ -1,12 +1,14 @@
+import { CooperatedEntity } from '../cooperated/entities/cooperated.entity';
 import { Module } from '@nestjs/common';
-import { RequestService } from './request.service';
 import { RequestController } from './request.controller';
-import { TypeOrmModule } from '@nestjs/typeorm';
 import { RequestEntity } from './entities/request.entity';
+import { RequestService } from './request.service';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { User } from '../user/entities/user.entity';
+import { UsersModule } from '../user/users.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([RequestEntity, User])],
+  imports: [TypeOrmModule.forFeature([RequestEntity, User, CooperatedEntity]), UsersModule],
   controllers: [RequestController],
   providers: [RequestService],
 })

--- a/src/modules/request/request.service.ts
+++ b/src/modules/request/request.service.ts
@@ -13,6 +13,7 @@ import { Repository } from "typeorm";
 import { UpdateRequestDto } from "./dto/update-request.dto";
 import { User } from "../user/entities/user.entity";
 import { UsersService } from "../user/users.service";
+import { HashGeneratorUtil } from "src/utils/hash-generator";
 
 @Injectable()
 export class RequestService {
@@ -158,6 +159,7 @@ export class RequestService {
     userDto.email = cooperated.email;
     userDto.firstName = cooperated.firstName;
     userDto.lastName = cooperated.lastName;
+    userDto.password = HashGeneratorUtil.generate();
     userDto.document = cooperated.document ?? '';
     userDto.telephone = cooperated.phone ?? ''
     return userDto

--- a/src/modules/request/request.service.ts
+++ b/src/modules/request/request.service.ts
@@ -1,22 +1,30 @@
-import { HttpException, HttpStatus, Injectable, NotFoundException, UnprocessableEntityException } from "@nestjs/common";
 import { CreateRequestDto } from "./dto/create-request.dto";
-import { UpdateRequestDto } from "./dto/update-request.dto";
-import { Repository } from "typeorm";
-import { RequestEntity } from "./entities/request.entity";
+import { CreateRequestForOthersDto } from "./dto/create-request-for-others.dto";
+import { CreateUserDto } from "../user/dto/create-user.dto";
+import { CooperatedEntity } from '../cooperated/entities/cooperated.entity';
+import { EntityCondition } from "src/utils/types/entity-condition.type";
+import { HttpException, HttpStatus, Injectable} from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
 import { IPaginationOptions } from "src/utils/types/pagination-options";
-import { User } from "../user/entities/user.entity";
-import { EntityCondition } from "src/utils/types/entity-condition.type";
-import { NullableType } from "src/utils/types/nullable.type";
 import { JwtPayloadType } from "../auth/strategies/types/jwt-payload.type";
+import { NullableType } from "src/utils/types/nullable.type";
+import { RequestEntity } from "./entities/request.entity";
+import { Repository } from "typeorm";
+import { UpdateRequestDto } from "./dto/update-request.dto";
+import { User } from "../user/entities/user.entity";
+import { UsersService } from "../user/users.service";
 
 @Injectable()
 export class RequestService {
   constructor(
     @InjectRepository(RequestEntity)
     private requestRepository: Repository<RequestEntity>,
+    @InjectRepository(CooperatedEntity)
+    private cooperatedRepository: Repository<CooperatedEntity>,
     @InjectRepository(User)
     private userRepository: Repository<User>,
+
+    private readonly usersService: UsersService
   ) {}
 
   async create(userJwtPayload: JwtPayloadType, createRequestDto: CreateRequestDto) {
@@ -48,6 +56,77 @@ export class RequestService {
     );
   }
 
+  async createForOthers(userJwtPayload: JwtPayloadType, createRequestForOthersDto: CreateRequestForOthersDto) {
+    const currentUser = await this.userRepository.findOne({
+      where: {
+        id: userJwtPayload.id,
+      },
+    });
+
+    if (!currentUser) {
+      throw new HttpException(
+        {
+          status: HttpStatus.UNPROCESSABLE_ENTITY,
+          errors: {
+            user: "userNotFound",
+          },
+        },
+        HttpStatus.UNPROCESSABLE_ENTITY,
+      );
+    }
+
+    const assistedUser = await this.userRepository.findOne({
+      where: {
+        document: createRequestForOthersDto.documentOfAssisted,
+      },
+    })
+
+    if(assistedUser) {
+      return this.requestRepository.save(
+        this.requestRepository.create({
+          ...createRequestForOthersDto,
+          user: {
+            id: assistedUser.id,
+          },
+          godFather: {
+            id: currentUser.id,
+          }
+        }),
+      );
+    }else {
+      const assistedCooperated = await this.cooperatedRepository.findOne({
+        where: {
+          document: createRequestForOthersDto.documentOfAssisted
+        }
+      })
+      
+      if (!assistedCooperated) {
+        throw new HttpException(
+          {
+            status: HttpStatus.UNPROCESSABLE_ENTITY,
+            errors: {
+              assisted: "assisted Not Found, please create a new user for this assisted",
+            },
+          },
+          HttpStatus.UNPROCESSABLE_ENTITY,
+        );
+      }
+
+      const newUser = await this.usersService.create(this.transformCooperatedToCreateUserDto(assistedCooperated));
+      return this.requestRepository.save(
+        this.requestRepository.create({
+          ...createRequestForOthersDto,
+          user: {
+            id: newUser.id,
+          },
+          godFather: {
+            id: currentUser.id,
+          }
+        }),
+      );
+    }
+  }
+
   findManyWithPagination(paginationOptions: IPaginationOptions): Promise<RequestEntity[]> {
     return this.requestRepository.find({
       skip: (paginationOptions.page - 1) * paginationOptions.limit,
@@ -72,5 +151,15 @@ export class RequestService {
 
   async remove(id: number): Promise<void> {
     this.requestRepository.softDelete(id);
+  }
+
+  transformCooperatedToCreateUserDto(cooperated: CooperatedEntity): CreateUserDto {
+    const userDto = new CreateUserDto();
+    userDto.email = cooperated.email;
+    userDto.firstName = cooperated.firstName;
+    userDto.lastName = cooperated.lastName;
+    userDto.document = cooperated.document ?? '';
+    userDto.telephone = cooperated.phone ?? ''
+    return userDto
   }
 }


### PR DESCRIPTION
Foi solicitada a criação do endpoint /requests/godfather para permitir que um usuário crie uma request em nome de outro, assumindo assim o papel de godfather.
Diante disso foi criado um novo dto que contem o documento do "assisted".  É verificado se o documento pertence a algum usuário já cadastrado no sistema, caso exista ele será cadastrado como o "user" da request, caso não exista o usuário, será consultado se há um "cooperated" cadastrado com o documento, caso tenha, será criado um usuário a partir dos dados registrados no "cooperated" e com uma senha gerada pelo HashGeneratorUtil tendo assim o proprietario desse novo usuario utilizar a opção de esqueci a senha caso desejar utilizar o usuario. Caso nenhum caso sejá atendido, retorna Exception "UNPROCESSABLE_ENTITY"

Para realizar testes utilizar o Swagger.