### PR TITLE
:sparkles: feat: Enviando userId quando cooperado ja esta registrado como usuario

### DIFF
--- a/src/modules/auth/dto/auth-get-document.dto.ts
+++ b/src/modules/auth/dto/auth-get-document.dto.ts
@@ -1,5 +1,6 @@
 import { ApiProperty } from "@nestjs/swagger";
 import { IsString, MinLength } from "class-validator";
+import { NumericOnlyTransform } from "src/infrastructure/custom-transforms";
 
 export class GetDocumentBodyDto {
   @ApiProperty({
@@ -7,5 +8,33 @@ export class GetDocumentBodyDto {
   })
   @MinLength(11)
   @IsString()
+  @NumericOnlyTransform()
   document: string;
+}
+
+export class GetDocumentResponseDto {
+  @ApiProperty({
+    example: "Morgan Stark",
+  })
+  name?: string | null;
+
+  @ApiProperty({
+    example: "14267215014",
+  })
+  document?: string | null;
+
+  @ApiProperty({
+    example: "example@example.com",
+  })
+  email?: string | null;
+
+  @ApiProperty({
+    example: "5511999999999",
+  })
+  phone?: string | null;
+
+  @ApiProperty({
+    example: 23,
+  })
+  userId?: number | null;
 }

--- a/src/modules/cooperated/cooperated.controller.ts
+++ b/src/modules/cooperated/cooperated.controller.ts
@@ -26,7 +26,7 @@ import { InfinityPaginationResultType } from '../../utils/types/infinity-paginat
 import { CooperatedEntity } from './entities/cooperated.entity';
 import { infinityPagination } from '../../utils/infinity-pagination';
 import { NullableType } from '../../utils/types/nullable.type';
-import { GetDocumentBodyDto } from '../auth/dto/auth-get-document.dto';
+import { GetDocumentBodyDto, GetDocumentResponseDto } from '../auth/dto/auth-get-document.dto';
 
 @ApiTags('Cooperateds')
 @Controller({
@@ -41,12 +41,8 @@ export class CooperatedController {
   })
   @Post("/document/validate")
   @HttpCode(HttpStatus.OK)
-  public async validateDocument(@Body() body: GetDocumentBodyDto): Promise<{name?: string,
-    document?: string,
-    email?: string,
-    phone?: string}
-  > {
-    return await this.cooperatedService.validateDocument(body.document);
+  public async validateDocument(@Body() body: GetDocumentBodyDto): Promise<GetDocumentResponseDto> {
+    return this.cooperatedService.validateDocument(body.document);
   }
 
   @Post()

--- a/src/modules/cooperated/entities/cooperated.entity.ts
+++ b/src/modules/cooperated/entities/cooperated.entity.ts
@@ -1,9 +1,10 @@
-import { Column, CreateDateColumn, DeleteDateColumn, Entity, Index, ManyToOne, PrimaryGeneratedColumn, UpdateDateColumn } from "typeorm";
-import { EntityHelper } from "../../../utils/entity-helper";
+import { Entity, PrimaryGeneratedColumn, Column, Index, ManyToOne, CreateDateColumn, UpdateDateColumn, DeleteDateColumn, OneToOne, JoinColumn } from "typeorm";
 import { Expose } from "class-transformer";
+import { EntityHelper } from "src/utils/entity-helper";
 import { OrganizationEntity } from "src/modules/organization/entities/organization.entity";
+import { User } from "src/modules/user/entities/user.entity";
 
-@Entity({name: 'cooperated'})
+@Entity({ name: "cooperated" })
 export class CooperatedEntity extends EntityHelper {
   @PrimaryGeneratedColumn()
   id: number;
@@ -29,6 +30,10 @@ export class CooperatedEntity extends EntityHelper {
   @ManyToOne(() => OrganizationEntity, { eager: false })
   organization?: OrganizationEntity | null;
 
+  @OneToOne(() => User, user => user.cooperated)
+  @JoinColumn()
+  user: User;
+
   @CreateDateColumn()
   createdAt: Date;
 
@@ -37,4 +42,8 @@ export class CooperatedEntity extends EntityHelper {
 
   @DeleteDateColumn()
   deletedAt: Date;
+
+  get fullName() {
+    return `${this.firstName} ${this.lastName}`;
+  }
 }

--- a/src/modules/user/users.service.ts
+++ b/src/modules/user/users.service.ts
@@ -6,7 +6,6 @@ import { DeepPartial, Repository } from 'typeorm';
 import { CreateUserDto } from './dto/create-user.dto';
 import { User } from './entities/user.entity';
 import { NullableType } from '../../utils/types/nullable.type';
-import { OrganizationEntity } from '../organization/entities/organization.entity';
 import { CooperatedEntity } from '../cooperated/entities/cooperated.entity';
 
 @Injectable()
@@ -16,8 +15,6 @@ export class UsersService {
     private usersRepository: Repository<User>,
     @InjectRepository(CooperatedEntity)
     private cooperatedRepository: Repository<CooperatedEntity>,
-    @InjectRepository(OrganizationEntity)
-    private organizationRepository: Repository<OrganizationEntity>
     
   ) {}
 


### PR DESCRIPTION
### Por que a mudança é necessária?
Esta mudança é necessária para melhorar a funcionalidade da função `validateDocument` na API. Anteriormente, a função não retornava o `userId` quando havia um usuário vinculado ao cooperado. Agora, com a implementação de um left join e a seleção apenas dos campos necessários, garantimos que o `userId` seja retornado quando houver um usuário associado ao cooperado, além de reduzir o número de consultas e a quantidade de dados recuperados, tornando a aplicação mais eficiente.

### Como a alteração foi abordada?
A alteração foi abordada utilizando o query builder do TypeORM para realizar um left join entre as tabelas `cooperated` e `user`. Através do método `select`, limitamos os campos recuperados apenas aos necessários para a resposta, incluindo o campo `userId` quando há um usuário associado ao cooperado.

### Como testar?
Para testar esta feature, você pode seguir os passos abaixo:

1. **Inicie a aplicação**: Certifique-se de que a API está em execução.
2. **Acesse o Swagger**: Vá até a interface do Swagger gerada pela aplicação, geralmente acessível via URL `/api`.
3. **Teste a Rota**: Utilize o endpoint para validar o documento, fornecendo um documento válido para a consulta (deve estar registrado na tabela user e cooperated com o mesmo document e haver um vinculo de id entre eles).
4. **Verifique a Resposta**: A resposta deve incluir os campos `name`, `document`, `email`, `phone`, e `userId` (quando houver um usuário vinculado). Certifique-se de que a resposta está correta e que todos os campos esperados estão presentes.
