### PR TITLE
:bug: fix: Ajustando request help type e request status erro de digitação

### DIFF
--- a/src/modules/request/dto/create-request.dto.ts
+++ b/src/modules/request/dto/create-request.dto.ts
@@ -25,14 +25,14 @@ export class CreateRequestDto {
 
   @ApiProperty({ type: RequestStatusEntity })
   @IsOptional()
-  @Validate(IsExist, ['RequestStatus', 'id'], {
+  @Validate(IsExist, ['request_status', 'id'], {
     message: 'statusNotExists',
   })
   status?: RequestStatusEntity;
 
   @ApiProperty({ type: RequestHelpTypeEntity })
   @IsNotEmpty()
-  @Validate(IsExist, ['RequestHelpType', 'id'], {
+  @Validate(IsExist, ['request_help_type', 'id'], {
     message: 'helpTypeNotExists',
   })
   helpType: RequestHelpTypeEntity;


### PR DESCRIPTION
# Por que a mudança é necessária?
Wellgenio avisou que o endpoint POST Request nao estava funcionando e estava retornando 401. Quando fui testar, recebi um unmmaped error, pois os tipos request help type e request status estavam incorretos no dto. 
O 401, no entanto, deve ser a falta do Bearer token na requisicao

# Como a alteração foi abordada?
Alteracao para nome correto dos atributos citados

# Como testar?
Usar o swagger para cadastrar uma requisicao válida
