### PR TITLE
Fix: Updates cooperated relation when user is registered

### DIFF
--- a/src/modules/auth/auth.module.ts
+++ b/src/modules/auth/auth.module.ts
@@ -13,6 +13,7 @@ import { IsNotExist } from 'src/utils/validators/is-not-exists.validator';
 import { SessionModule } from 'src/modules/session/session.module';
 import { JwtRefreshStrategy } from './strategies/jwt-refresh.strategy';
 import { OrganizationModule } from '../organization/organization.module';
+import { CooperatedModule } from '../cooperated/cooperated.module';
 
 @Module({
   imports: [
@@ -23,6 +24,7 @@ import { OrganizationModule } from '../organization/organization.module';
     MailModule,
     OrganizationModule,
     JwtModule.register({}),
+    CooperatedModule
   ],
   controllers: [AuthController],
   providers: [

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -32,6 +32,7 @@ import { JwtRefreshPayloadType } from './strategies/types/jwt-refresh-payload.ty
 import { Session } from 'src/modules/session/entities/session.entity';
 import { JwtPayloadType } from './strategies/types/jwt-payload.type';
 import { OrganizationService } from 'src/modules/organization/organization.service';
+import { CooperatedService } from '../cooperated/cooperated.service';
 
 @Injectable()
 export class AuthService {
@@ -43,6 +44,7 @@ export class AuthService {
     private sessionService: SessionService,
     private mailService: MailService,
     private configService: ConfigService<AllConfigType>,
+    private cooperatedService: CooperatedService
   ) { }
 
   async validateLogin(loginDto: AuthEmailLoginDto, onlyAdmin: boolean): Promise<LoginResponseType> {
@@ -211,7 +213,7 @@ export class AuthService {
       .update(randomStringGenerator())
       .digest('hex');
 
-    await this.usersService.create({
+    let registeredData = await this.usersService.create({
       ...data,
       email: data.email,
       role: {
@@ -222,6 +224,9 @@ export class AuthService {
       } as UserStatus,
       hash,
     });
+
+    await this.cooperatedService.update(registeredData.cooperated.id, {user: registeredData});
+
   }
 
   async confirmEmail(hash: string): Promise<void> {

--- a/src/modules/cooperated/cooperated.module.ts
+++ b/src/modules/cooperated/cooperated.module.ts
@@ -12,5 +12,6 @@ import { OrganizationEntity } from "../organization/entities/organization.entity
   imports: [TypeOrmModule.forFeature([CooperatedEntity, OrganizationEntity])],
   controllers: [CooperatedController],
   providers: [IsExist, IsNotExist, CooperatedService, OrganizationService],
+  exports: [CooperatedService]
 })
 export class CooperatedModule {}


### PR DESCRIPTION
# Por que a mudança é necessária?
Quando um usuário é registrado atualmente, a tabela de cooperados fica com o campo userId nulo, não efetivando o vínculo para consultas

# Como a alteração foi abordada?
Adicionado um update via ID do cooperado após o usuário ter sido registrado na rota de register.

# Como testar?
- Criar um cooperado
- Registrar um usuário com o mesmo CPF
- Consultar na tabela de cooperado se o campo userId foi devidamente atualizado
