### PR TITLE
:sparkles: feat: returning 404 when does not find the antity searched

### DIFF
--- a/src/infrastructure/exceptions/resource-not-found.exception.ts
+++ b/src/infrastructure/exceptions/resource-not-found.exception.ts
@@ -1,1 +1,5 @@
-export class ResourceNotFoundException extends Error {}
+export class ResourceNotFoundException extends Error {
+  constructor(message = "Resource not found") {
+    super(message);
+  }
+}

--- a/src/modules/accidents/accidents.service.ts
+++ b/src/modules/accidents/accidents.service.ts
@@ -8,6 +8,7 @@ import { EntityCondition } from "src/utils/types/entity-condition.type";
 import { NullableType } from "src/utils/types/nullable.type";
 import { RequestService } from "../request/request.service";
 import { FileService } from "../file/file.service";
+import { ResourceNotFoundException } from "src/infrastructure/exceptions/resource-not-found.exception";
 
 @Injectable()
 export class AccidentsService {
@@ -38,10 +39,16 @@ export class AccidentsService {
     });
   }
 
-  findOne(fields: EntityCondition<AccidentEntity>): Promise<NullableType<AccidentEntity>> {
-    return this.accidentRepository.findOne({
+  async findOne(fields: EntityCondition<AccidentEntity>): Promise<NullableType<AccidentEntity>> {
+    const accident = await this.accidentRepository.findOne({
       where: fields,
     });
+
+    if (!accident) {
+      throw new ResourceNotFoundException();
+    }
+
+    return accident;
   }
 
   update(id: AccidentEntity["id"], payload: DeepPartial<AccidentEntity>): Promise<AccidentEntity> {

--- a/src/modules/cooperated/cooperated.service.ts
+++ b/src/modules/cooperated/cooperated.service.ts
@@ -8,6 +8,7 @@ import { EntityCondition } from "../../utils/types/entity-condition.type";
 import { NullableType } from "../../utils/types/nullable.type";
 import { OrganizationService } from "../organization/organization.service";
 import { GetDocumentResponseDto } from "../auth/dto/auth-get-document.dto";
+import { ResourceNotFoundException } from "src/infrastructure/exceptions/resource-not-found.exception";
 
 @Injectable()
 export class CooperatedService {
@@ -32,10 +33,16 @@ export class CooperatedService {
     });
   }
 
-  findOne(fields: EntityCondition<CooperatedEntity>): Promise<NullableType<CooperatedEntity>> {
-    return this.cooperatedRepository.findOne({
+  async findOne(fields: EntityCondition<CooperatedEntity>): Promise<NullableType<CooperatedEntity>> {
+    const cooperated = await this.cooperatedRepository.findOne({
       where: fields,
     });
+
+    if (!cooperated) {
+      throw new ResourceNotFoundException();
+    }
+
+    return cooperated;
   }
 
   update(id: CooperatedEntity["id"], payload: DeepPartial<CooperatedEntity>): Promise<CooperatedEntity> {

--- a/src/modules/forgot/forgot.service.ts
+++ b/src/modules/forgot/forgot.service.ts
@@ -1,9 +1,10 @@
-import { Injectable } from '@nestjs/common';
-import { InjectRepository } from '@nestjs/typeorm';
-import { FindOptions } from 'src/utils/types/find-options.type';
-import { DeepPartial, Repository } from 'typeorm';
-import { Forgot } from './entities/forgot.entity';
-import { NullableType } from '../../utils/types/nullable.type';
+import { Injectable } from "@nestjs/common";
+import { InjectRepository } from "@nestjs/typeorm";
+import { FindOptions } from "src/utils/types/find-options.type";
+import { DeepPartial, Repository } from "typeorm";
+import { Forgot } from "./entities/forgot.entity";
+import { NullableType } from "../../utils/types/nullable.type";
+import { ResourceNotFoundException } from "src/infrastructure/exceptions/resource-not-found.exception";
 
 @Injectable()
 export class ForgotService {
@@ -13,9 +14,15 @@ export class ForgotService {
   ) {}
 
   async findOne(options: FindOptions<Forgot>): Promise<NullableType<Forgot>> {
-    return this.forgotRepository.findOne({
+    const forgot = await this.forgotRepository.findOne({
       where: options.where,
     });
+
+    if (!forgot) {
+      throw new ResourceNotFoundException();
+    }
+
+    return forgot;
   }
 
   async findMany(options: FindOptions<Forgot>): Promise<Forgot[]> {
@@ -28,7 +35,7 @@ export class ForgotService {
     return this.forgotRepository.save(this.forgotRepository.create(data));
   }
 
-  async softDelete(id: Forgot['id']): Promise<void> {
+  async softDelete(id: Forgot["id"]): Promise<void> {
     await this.forgotRepository.softDelete(id);
   }
 }

--- a/src/modules/organization/organization.service.ts
+++ b/src/modules/organization/organization.service.ts
@@ -1,35 +1,39 @@
-import { Body, Injectable } from '@nestjs/common';
-import { CreateOrganizationDto } from './dto/create-organization.dto';
-import { UpdateOrganizationDto } from './dto/update-organization.dto';
-import { OrganizationEntity } from './entities/organization.entity';
-import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
-import { EntityCondition } from 'src/utils/types/entity-condition.type';
-import { NullableType } from 'src/utils/types/nullable.type';
+import { Body, Injectable } from "@nestjs/common";
+import { CreateOrganizationDto } from "./dto/create-organization.dto";
+import { UpdateOrganizationDto } from "./dto/update-organization.dto";
+import { OrganizationEntity } from "./entities/organization.entity";
+import { InjectRepository } from "@nestjs/typeorm";
+import { Repository } from "typeorm";
+import { EntityCondition } from "src/utils/types/entity-condition.type";
+import { NullableType } from "src/utils/types/nullable.type";
+import { ResourceNotFoundException } from "src/infrastructure/exceptions/resource-not-found.exception";
 
 @Injectable()
 export class OrganizationService {
-
   constructor(
     @InjectRepository(OrganizationEntity)
     private organizationRepository: Repository<OrganizationEntity>,
-  ) { }
+  ) {}
 
   create(createOrganizationDto) {
-    console.log(createOrganizationDto)
-    return this.organizationRepository.save(
-      this.organizationRepository.create(createOrganizationDto),
-    );
+    console.log(createOrganizationDto);
+    return this.organizationRepository.save(this.organizationRepository.create(createOrganizationDto));
   }
 
   findAll() {
     return `This action returns all organization`;
   }
 
-  findOne(fields: EntityCondition<OrganizationEntity>): Promise<NullableType<OrganizationEntity>> {
-    return this.organizationRepository.findOne({
+  async findOne(fields: EntityCondition<OrganizationEntity>): Promise<NullableType<OrganizationEntity>> {
+    const organization = await this.organizationRepository.findOne({
       where: fields,
     });
+
+    if (!organization) {
+      throw new ResourceNotFoundException();
+    }
+
+    return organization;
   }
 
   update(id: number, updateOrganizationDto: UpdateOrganizationDto) {

--- a/src/modules/receipt/receipt.service.ts
+++ b/src/modules/receipt/receipt.service.ts
@@ -8,6 +8,7 @@ import { RequestStatusEnum } from "src/modules/request/enums/status.enum";
 import { IPaginationOptions } from "src/utils/types/pagination-options";
 import { NullableType } from "src/utils/types/nullable.type";
 import { EntityCondition } from "src/utils/types/entity-condition.type";
+import { ResourceNotFoundException } from "src/infrastructure/exceptions/resource-not-found.exception";
 
 @Injectable()
 export class ReceiptService {
@@ -64,10 +65,16 @@ export class ReceiptService {
     });
   }
 
-  findOne(fields: EntityCondition<ReceiptEntity>): Promise<NullableType<ReceiptEntity>> {
-    return this.receiptRepository.findOne({
+  async findOne(fields: EntityCondition<ReceiptEntity>): Promise<NullableType<ReceiptEntity>> {
+    const receipt = await this.receiptRepository.findOne({
       where: fields,
     });
+
+    if (!receipt) {
+      throw new ResourceNotFoundException();
+    }
+
+    return receipt;
   }
 
   update(id: ReceiptEntity["id"], payload: DeepPartial<ReceiptEntity>): Promise<ReceiptEntity> {

--- a/src/modules/user/address/address.service.ts
+++ b/src/modules/user/address/address.service.ts
@@ -1,33 +1,32 @@
-import { HttpException, HttpStatus, Injectable} from '@nestjs/common';
-import { CreateAddressDto } from './dto/create-address.dto';
-import { UpdateAddressDto } from './dto/update-address.dto';
-import { AddressEntity } from './entities/address.entity';
-import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
-import { User } from '../entities/user.entity';
-import { EntityCondition } from '../../../utils/types/entity-condition.type';
-import { NullableType } from '../../../utils/types/nullable.type';
-
+import { HttpException, HttpStatus, Injectable } from "@nestjs/common";
+import { CreateAddressDto } from "./dto/create-address.dto";
+import { UpdateAddressDto } from "./dto/update-address.dto";
+import { AddressEntity } from "./entities/address.entity";
+import { InjectRepository } from "@nestjs/typeorm";
+import { Repository } from "typeorm";
+import { User } from "../entities/user.entity";
+import { EntityCondition } from "../../../utils/types/entity-condition.type";
+import { NullableType } from "../../../utils/types/nullable.type";
+import { ResourceNotFoundException } from "src/infrastructure/exceptions/resource-not-found.exception";
 
 @Injectable()
 export class AddressService {
-
   constructor(
     @InjectRepository(AddressEntity)
     private addressRepository: Repository<AddressEntity>,
     @InjectRepository(User)
     private userRepository: Repository<User>,
-  ) { }
+  ) {}
 
   async create(createAddressDto: CreateAddressDto) {
-    const user = await this.userRepository.findOne({where: {id: createAddressDto.userId}})
+    const user = await this.userRepository.findOne({ where: { id: createAddressDto.userId } });
 
-    if(!user) {
+    if (!user) {
       throw new HttpException(
         {
           status: HttpStatus.UNPROCESSABLE_ENTITY,
           errors: {
-            user: 'userNotFound',
+            user: "userNotFound",
           },
         },
         HttpStatus.UNPROCESSABLE_ENTITY,
@@ -37,7 +36,7 @@ export class AddressService {
     return await this.addressRepository.save(
       this.addressRepository.create({
         ...createAddressDto,
-        user
+        user,
       }),
     );
   }
@@ -46,10 +45,16 @@ export class AddressService {
     return `This action returns all address`;
   }
 
-  findOne(fields: EntityCondition<AddressEntity>): Promise<NullableType<AddressEntity>> {
-    return this.addressRepository.findOne({
+  async findOne(fields: EntityCondition<AddressEntity>): Promise<NullableType<AddressEntity>> {
+    const address = await this.addressRepository.findOne({
       where: fields,
     });
+
+    if (!address) {
+      throw new ResourceNotFoundException();
+    }
+
+    return address;
   }
 
   update(id: number, updateAddressDto: UpdateAddressDto) {
@@ -57,6 +62,6 @@ export class AddressService {
   }
 
   remove(id: number) {
-    this.addressRepository.delete({id})
+    this.addressRepository.delete({ id });
   }
 }

--- a/test/utils/constants.ts
+++ b/test/utils/constants.ts
@@ -1,7 +1,7 @@
 export const APP_URL = `http://localhost:${process.env.APP_PORT}`;
-export const TESTER_EMAIL = 'john.doe@example.com';
+export const TESTER_EMAIL = 'john.stark@coopartilhar.com';
 export const TESTER_PASSWORD = 'password123';
-export const ADMIN_EMAIL = 'admin@example.com';
+export const ADMIN_EMAIL = 'admin@coopartilhar.com.br';
 export const ADMIN_PASSWORD = 'password123';
 export const MAIL_HOST = process.env.MAIL_HOST;
 export const MAIL_PORT = process.env.MAIL_CLIENT_PORT;


### PR DESCRIPTION
# Por que a mudança é necessária?
Essa mudança é necessária para melhorar a experiência do usuário ao interagir com a API. Anteriormente, quando uma entidade não era encontrada, o sistema não retornava uma resposta clara sobre o status da busca. Com essa alteração, quando a entidade procurada não for encontrada, o sistema retornará um erro 404, informando claramente que o recurso não foi localizado. Essa demanda surgiu da necessidade de padronizar as respostas da API e facilitar o tratamento de erros no lado do cliente.


# Como a alteração foi abordada?
Foi implementada uma verificação no método findOne dos serviços das entidades. Agora, quando a entidade não é encontrada, o sistema lança uma NotFoundException (erro 404). Essa modificação garante que todos os endpoints que utilizam estes serviços passem a retornar o status correto quando uma entidade não for encontrada.


# Como testar?
Para testar essa funcionalidade, você pode realizar chamadas aos endpoints listados abaixo com parâmetros que não correspondam a nenhuma entidade existente no banco de dados. A API deve retornar um erro 404. Não há passos manuais específicos além de garantir que as chamadas estejam devidamente configuradas para buscar entidades inexistentes.

Os endpoints alterados são:

- accidents
- cooperated
- file
- forgot
- organization
- receipt
- request
- session
- user
- address
