### PR TITLE
:sparkles: feat: Retornando o telefone no endpoint de Requisicao

### DIFF
--- a/src/modules/request/request.controller.ts
+++ b/src/modules/request/request.controller.ts
@@ -1,18 +1,33 @@
-import { Controller, Get, Post, Body, Patch, Param, Delete, UseGuards, HttpStatus, HttpCode, DefaultValuePipe, ParseIntPipe, Query, Request, Response, Res } from '@nestjs/common';
-import { RequestService } from './request.service';
-import { CreateRequestDto } from './dto/create-request.dto';
-import { UpdateRequestDto } from './dto/update-request.dto';
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Patch,
+  Param,
+  Delete,
+  UseGuards,
+  HttpStatus,
+  HttpCode,
+  DefaultValuePipe,
+  ParseIntPipe,
+  Query,
+  Request,
+  SerializeOptions,
+} from "@nestjs/common";
+import { RequestService } from "./request.service";
+import { CreateRequestDto } from "./dto/create-request.dto";
+import { UpdateRequestDto } from "./dto/update-request.dto";
 import { ApiBearerAuth, ApiQuery, ApiTags } from "@nestjs/swagger";
-import { UserRoleEnum } from '../user/enums/roles.enum';
-import { Roles } from '../user/roles/roles.decorator';
-import { AuthGuard } from '@nestjs/passport';
-import { RolesGuard } from '../user/roles/roles.guard';
-import { infinityPagination } from 'src/utils/infinity-pagination';
-import { NullableType } from 'src/utils/types/nullable.type';
-import { RequestEntity } from './entities/request.entity';
-import { CreateRequestForOthersDto } from './dto/create-request-for-others.dto';
+import { UserRoleEnum } from "../user/enums/roles.enum";
+import { Roles } from "../user/roles/roles.decorator";
+import { AuthGuard } from "@nestjs/passport";
+import { RolesGuard } from "../user/roles/roles.guard";
+import { infinityPagination } from "src/utils/infinity-pagination";
+import { NullableType } from "src/utils/types/nullable.type";
+import { RequestEntity } from "./entities/request.entity";
+import { CreateRequestForOthersDto } from "./dto/create-request-for-others.dto";
 import { OrderingEnum } from "./enums/ordering-filter.enum";
-
 
 @ApiBearerAuth()
 @Roles(UserRoleEnum.user)
@@ -33,12 +48,12 @@ export class RequestController {
 
   @Post("/godfather")
   @HttpCode(HttpStatus.CREATED)
-  async createForOthers(@Request() request, @Body() createRequestForOthersDto: CreateRequestForOthersDto) {   
+  async createForOthers(@Request() request, @Body() createRequestForOthersDto: CreateRequestForOthersDto) {
     return await this.requestService.createForOthers(request.user, createRequestForOthersDto);
   }
 
-  @Get()
-  @ApiQuery({ name: 'ordering', enum: OrderingEnum, required: false, description: 'ASC para ascendente e DESC para descendente' })
+  @Get("/list")
+  @ApiQuery({ name: "ordering", enum: OrderingEnum, required: false, description: "ASC para ascendente e DESC para descendente" })
   async findAll(
     @Query("page", new DefaultValuePipe(1), ParseIntPipe) page: number,
     @Query("limit", new DefaultValuePipe(10), ParseIntPipe) limit: number,
@@ -58,6 +73,9 @@ export class RequestController {
     );
   }
 
+  @SerializeOptions({
+    groups: ["me"],
+  })
   @Get(":id")
   findOne(@Param("id") id: string): Promise<NullableType<RequestEntity>> {
     return this.requestService.findOne({ id: +id });


### PR DESCRIPTION
# Por que a mudança é necessária?
Frontend precisa da informacao do telefone do usuário pelo endpoint de requisicao.

# Como a alteração foi abordada?
A entidade usuario ja esta sendo retornada, mas alguns campos estavam marcados como "group": "me". Nao sei exatamente como funciona, mas eh diretamente ligado aos groups que o controller aceita serializar. O que tive de fazer foi adicionar essa informacao no controller.

Tambem corrigi a falta do sufixo "list" no endpoint de lista de requisicoes.

# Como testar?
Basta acionar o endpoint
localhost:3000/api/v1/requests/1
ou usar o swagger e verificar se o telephone esta presente
