### PR TITLE
Feat: Implements get request feed

### DIFF
--- a/src/utils/types/pagination-options.ts
+++ b/src/utils/types/pagination-options.ts
@@ -1,7 +1,9 @@
 import { OrderingEnum } from "src/modules/request/enums/ordering-filter.enum";
+import { WhereExpressionBuilder } from "typeorm";
 
 export interface IPaginationOptions {
   page: number;
   limit: number;
-  ordering?: OrderingEnum
+  ordering?: OrderingEnum;
+  where?: object | null
 }


### PR DESCRIPTION
# Por que a mudança é necessária?
A rota de obtenção de requests atualmente retorna todas as requests, e não faz o filtro de em aberto e sem padrinho, Para o feed inicial, conforme protótipos no Figma, é necessario uma rota que atenda esses critérios

# Como a alteração foi abordada?
Implementada uma rota específica para o feed de requests, que aplica os filtros necessários para obter requests em aberto que não possuem um padrinho.

# Como testar?

- Criar uma solicitação com um usuário
- Consumir a rota feed (a request deve ser retornada no payload)
- Alterar o status da solicitação para concluido ou outra situação e testar a rota, o payload deve vir vazio
- Colocar um padrinho na solicitação também deve fazer com que a rota de feed não retorne os dados da solicitação